### PR TITLE
Masque support

### DIFF
--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -395,11 +395,6 @@ function buttonProto:UpdateBorder(isolatedEvent)
 			elseif quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
 				local v = 1 - 0.5 * addon.db.profile.qualityOpacity
 				texture, blendMode, r, g, b = true, "MOD", v, v, v
-
-				if Masque then
-					-- Do nothing here: Masque hook will handle icon + border tint
-					texture = nil -- prevent overwriting the Masque border here
-				end
 			end
 		end
 		if texture then
@@ -485,37 +480,15 @@ if Masque then
 		self.masqueData.Border      = iqTex
 		self.masqueData.QuestBorder = iqTex
 
-		local icon  = self.IconTexture
-
-
 		-- 2.b) Post-Masque: just force-show the texture if needed
-		if isQuest then
+		if isQuest or isJunk then
 			iqTex:SetDrawLayer("OVERLAY", 7)
-			iqTex:Show()
-			icon:SetBlendMode("DISABLE")
-			icon:SetVertexColor(1, 1, 1, 1)
-		elseif isJunk then
-			-- 1) icon: alpha-blend for a light fade, not full MOD tint
-			local base = addon.db.profile.qualityOpacity or 1
-			local v    = 1 - 0.25 * base   -- tweak “0.25” to taste (0.2–0.3 is nice)
-
-			icon:SetBlendMode("BLEND")
-			icon:SetVertexColor(1, 1, 1, 0.4)
-			icon:SetDrawLayer("OVERLAY", 7)
-
-			iqTex:SetBlendMode("BLEND")
-			iqTex:SetDrawLayer("BACKGROUND", 7)
 			iqTex:Show()
 		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
 			local r, g, b = GetItemQualityColor(quality)
 			iqTex:SetVertexColor(r, g, b, addon.db.profile.qualityOpacity)
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
-			icon:SetBlendMode("DISABLE")
-			icon:SetVertexColor(1, 1, 1, 1)
-		else
-			icon:SetBlendMode("DISABLE")
-			icon:SetVertexColor(1, 1, 1, 1)
 		end
 		-- (everything else—common items & empty slots—will now use Masque’s defaults)
 	end)

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -393,8 +393,13 @@ function buttonProto:UpdateBorder(isolatedEvent)
 				texture, x1, x2, y1, y2 = [[Interface\Buttons\UI-ActionButton-Border]], 14/64, 49/64, 15/64, 50/64
 				blendMode = "ADD"
 			elseif quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
-				local v = 1 - 0.5 * addon.db.profile.qualityOpacity
-				texture, blendMode, r, g, b = true, "MOD", v, v, v
+				if Masque then -- <<<< ADD THIS IF CONDITION
+					texture = nil -- Tell AdiBags to do nothing with the border for junk if Masque is on
+				else
+					-- Original AdiBags junk border logic (only if Masque is NOT active)
+					local v = 1 - 0.5 * addon.db.profile.qualityOpacity
+					texture, blendMode, r, g, b = true, "MOD", v, v, v
+				end -- <<<< END IF
 			end
 		end
 		if texture then
@@ -505,23 +510,47 @@ if Masque then
 			-- YOUR ORIGINAL LOGIC FOR isQuest (WHEN isJunk IS FALSE)
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
 
-		elseif isJunk then -- [[ CHANGE #2 FOR JUNK: Styling ]]
-			-- This block now ONLY executes if isJunk is true.
-			-- 1. Dim the icon (from your original non-Masque code's junk handling)
-			local base = addon.db.profile.qualityOpacity or 1
+		elseif isJunk then
+			-- 1. Dim the icon
 			icon:SetBlendMode("BLEND")
 			icon:SetVertexColor(1, 1, 1, 0.4)
-			if icon.SetDrawLayer then icon:SetDrawLayer("OVERLAY", 7) end
+			if icon.SetDrawLayer then icon:SetDrawLayer("ARTWORK", 1) end
 
-			-- 2. Style iqTex (which Masque has now skinned)
-			iqTex:SetTexture(nil)             -- Ensure no AdiBags texture.
-			iqTex:SetVertexColor(1, 1, 1, 1)  -- Ensure no AdiBags tint.
-			iqTex:SetBlendMode("BLEND")
-			iqTex:SetDrawLayer("OVERLAY", 1)  -- LAYER FOR MASQUE'S JUNK BORDER (try 0-6)
+			-- 2. Border styling
+			--iqTex:SetTexture(nil)
+			iqTex:SetVertexColor(0.5, 0.5, 0.5, 0.5)
+			iqTex:SetDrawLayer("OVERLAY", 10)
 			iqTex:Show()
 
+			--for i = 1, self:GetNumRegions() do
+			--	local region = select(i, self:GetRegions())
+			--	if region and region.GetObjectType and region:GetObjectType() == "Texture" then
+			--		local tex = region:GetTexture()
+			--		-- print(string.format("[Tex %d Original] = %s", i, tostring(tex)))
+			--
+			--		if tex then
+			--			-- Normalize backslashes to forward slashes
+			--			local normalizedTex = string.gsub(tex, "\\", "/")
+			--			-- print(string.format("[Tex %d Normalized] = %s", i, tostring(normalizedTex)))
+			--
+			--			-- Now search the normalized string
+			--			if normalizedTex:find("Masque_Caith/Textures/Border", 1, true) then
+			--				print("raised")
+			--				region:SetDrawLayer("OVERLAY", 10)
+			--				print("[+] Raised Masque_Caith Border '" .. tostring(tex) .. "' to OVERLAY/10")
+			--			end
+			--		end
+			--	end
+			--end
+
+
+
 		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
 			-- YOUR ORIGINAL LOGIC FOR QUALITY ITEMS (WHEN isJunk and isQuest ARE FALSE)
 			local r, g, b = GetItemQualityColor(quality)
 			local qualityOpacityVal = addon.db.profile.qualityOpacity
@@ -530,15 +559,9 @@ if Masque then
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
 
-			-- else: For common/white items, and any other case NOT covered above:
-			--       YOUR ORIGINAL CODE HAD NO EXPLICIT iqTex:Hide() HERE.
-			--       It relied on the original non-Masque UpdateBorder to have hidden it,
-			--       or for Masque's default handling. This behavior is PRESERVED.
-			--       If iqTex was shown by a previous condition and isn't explicitly hidden now,
-			--       it might remain visible. Your original code's implicit "else" is kept.
-			--       To be truly safe and match what usually happens for "no border", one would
-			--       add iqTex:Hide() in an explicit final 'else', but I will NOT add that
-			--       to strictly adhere to "only touch junk".
+		 else
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
 		end
 		-- (everything else—common items & empty slots—will now use Masque’s defaults) - YOUR COMMENT
 	end)

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -393,8 +393,8 @@ function buttonProto:UpdateBorder(isolatedEvent)
 				texture, x1, x2, y1, y2 = [[Interface\Buttons\UI-ActionButton-Border]], 14/64, 49/64, 15/64, 50/64
 				blendMode = "ADD"
 			elseif quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
-				--local v = 1 - 0.5 * addon.db.profile.qualityOpacity
-				--texture, blendMode, r, g, b = true, "MOD", v, v, v
+				local v = 1 - 0.5 * addon.db.profile.qualityOpacity
+				texture, blendMode, r, g, b = true, "MOD", v, v, v
 			end
 		end
 		if texture then
@@ -448,15 +448,14 @@ if Masque then
 
 	-- 2) Re-skin each time AdiBags updates the border
 	hooksecurefunc(buttonProto, "UpdateBorder", function(self)
-		local icon  = self.IconTexture
-		local iqTex = self.IconQuestTexture
+		local iqTex    = self.IconQuestTexture
+		local isJunk   = false
+		local quality, isQuest
 
-		-- Determine state
-		local isJunk, isQuest, quality = false, false, nil
 		if self.hasItem then
-			_, _, quality   = GetItemInfo(self.itemId)
-			local qi, qid   = GetContainerItemQuestInfo(self.bag, self.slot)
-			if addon.db.profile.questIndicator and (qi or qid) then
+			local _, _, q = GetItemInfo(self.itemId); quality = q
+			local questItem, questId = GetContainerItemQuestInfo(self.bag, self.slot)
+			if addon.db.profile.questIndicator and (questItem or questId) then
 				isQuest = true
 			end
 			if quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
@@ -464,7 +463,7 @@ if Masque then
 			end
 		end
 
-		-- Tell Masque to ignore the real border for junk
+		-- 2.a) Tell Masque to ignore the real border for junk items
 		if isJunk then
 			self.masqueData.Border      = dummyTex
 			self.masqueData.QuestBorder = dummyTex
@@ -473,46 +472,26 @@ if Masque then
 			self.masqueData.QuestBorder = iqTex
 		end
 
-		-- Re-register so Masque re-applies its skin
+		-- Re-register so Masque reapplies its skin
 		self.masqueGroup:RemoveButton(self)
 		self.masqueGroup:AddButton(self, self.masqueData)
+
+		-- Restore for next run
 		self.masqueData.Border      = iqTex
 		self.masqueData.QuestBorder = iqTex
 
-		-- Post-Masque: apply overlays
-		if isJunk then
-			-- 1) icon: alpha-blend for a light fade, not full MOD tint
-			local base = addon.db.profile.qualityOpacity or 1
-			local v    = 1 - 0.50 * base   -- tweak “0.25” to taste (0.2–0.3 is nice)
-			icon:SetBlendMode("BLEND")
-			icon:SetVertexColor(1, 1, 1, 0.4)
-
-
-			---- 2) border: keep your existing grey square
-			--iqTex:SetTexture("Interface\\Buttons\\WHITE8X8")
-			--iqTex:SetVertexColor(1, 0, 0, v)
-			--iqTex:SetBlendMode("MOD")
-			--iqTex:SetDrawLayer("OVERLAY", 50)
-			--iqTex:Show()
-		else
-			-- Reset icon for non-junk
-			icon:SetVertexColor(1, 1, 1, 1)
-			icon:SetBlendMode("BLEND")
-
-			if isQuest then
-				iqTex:SetDrawLayer("OVERLAY", 7)
-				iqTex:Show()
-
-			elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
-				local r, g, b = GetItemQualityColor(quality)
-				iqTex:SetVertexColor(r, g, b, addon.db.profile.qualityOpacity)
-				iqTex:SetDrawLayer("OVERLAY", 7)
-				iqTex:Show()
-			end
-			-- common & empty slots fall back to Masque defaults
+		-- 2.b) Post-Masque: just force-show the texture if needed
+		if isQuest or isJunk then
+			iqTex:SetDrawLayer("OVERLAY", 7)
+			iqTex:Show()
+		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
+			local r, g, b = GetItemQualityColor(quality)
+			iqTex:SetVertexColor(r, g, b, addon.db.profile.qualityOpacity)
+			iqTex:SetDrawLayer("OVERLAY", 7)
+			iqTex:Show()
 		end
+		-- (everything else—common items & empty slots—will now use Masque’s defaults)
 	end)
-
 
 	-- 3) Masque groups (unchanged)
 	buttonProto.masqueGroup     = Masque:Group(addonName, addon.L["Backpack button"])

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -468,18 +468,11 @@ if Masque then
 			end
 		end
 
-		-- [[ CHANGE #1 FOR JUNK: Masque Target ]]
-		-- Ensure Masque targets the REAL iqTex for junk items.
-		-- For non-junk items, your original logic of targeting iqTex is maintained.
 		local originalMasqueBorderTarget = self.masqueData.Border -- Store original before potentially changing for junk
 		if isJunk then
 			self.masqueData.Border      = iqTex -- Masque skins the real border for junk
 			self.masqueData.QuestBorder = iqTex -- Masque skins the real border for junk
 		else
-			-- This 'else' branch is your original logic for non-junk items,
-			-- ensuring self.masqueData.Border points to iqTex.
-			-- Since OnCreate already sets it to iqTex, this effectively means
-			-- self.masqueData.Border will be iqTex for non-junk too.
 			self.masqueData.Border      = iqTex
 			self.masqueData.QuestBorder = iqTex
 		end
@@ -490,17 +483,8 @@ if Masque then
 			self.masqueGroup:AddButton(self, self.masqueData)
 		end
 
-		-- Restore for next run - CRITICAL: Restore to what it was BEFORE this specific junk check
-		-- This ensures subsequent non-junk processing in other hooks or contexts sees the right value
-		-- if it was more complex than just iqTex. However, given OnCreate sets it to iqTex,
-		-- and non-junk also sets it to iqTex, this restoration is mainly for conceptual correctness
-		-- if the masqueData could be different. For this specific code, it will always restore to iqTex.
 		self.masqueData.Border      = originalMasqueBorderTarget
 		self.masqueData.QuestBorder = originalMasqueBorderTarget
-		-- If originalMasqueBorderTarget was always iqTex (due to OnCreate and your non-junk path),
-		-- then this is equivalent to:
-		-- self.masqueData.Border      = iqTex
-		-- self.masqueData.QuestBorder = iqTex
 
 
 		-- 2.b) Post-Masque: just force-show the texture if needed
@@ -520,33 +504,10 @@ if Masque then
 			if icon.SetDrawLayer then icon:SetDrawLayer("ARTWORK", 1) end
 
 			-- 2. Border styling
-			--iqTex:SetTexture(nil)
+			iqTex:SetTexture(nil)
 			iqTex:SetVertexColor(0.5, 0.5, 0.5, 0.5)
 			iqTex:SetDrawLayer("OVERLAY", 10)
 			iqTex:Show()
-
-			--for i = 1, self:GetNumRegions() do
-			--	local region = select(i, self:GetRegions())
-			--	if region and region.GetObjectType and region:GetObjectType() == "Texture" then
-			--		local tex = region:GetTexture()
-			--		-- print(string.format("[Tex %d Original] = %s", i, tostring(tex)))
-			--
-			--		if tex then
-			--			-- Normalize backslashes to forward slashes
-			--			local normalizedTex = string.gsub(tex, "\\", "/")
-			--			-- print(string.format("[Tex %d Normalized] = %s", i, tostring(normalizedTex)))
-			--
-			--			-- Now search the normalized string
-			--			if normalizedTex:find("Masque_Caith/Textures/Border", 1, true) then
-			--				print("raised")
-			--				region:SetDrawLayer("OVERLAY", 10)
-			--				print("[+] Raised Masque_Caith Border '" .. tostring(tex) .. "' to OVERLAY/10")
-			--			end
-			--		end
-			--	end
-			--end
-
-
 
 		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
 			icon:SetBlendMode("DISABLE")
@@ -563,7 +524,6 @@ if Masque then
 			icon:SetBlendMode("DISABLE")
 			icon:SetVertexColor(1, 1, 1, 1)
 		end
-		-- (everything else—common items & empty slots—will now use Masque’s defaults) - YOUR COMMENT
 	end)
 
 	-- 3) Masque groups (YOURS)

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -395,6 +395,11 @@ function buttonProto:UpdateBorder(isolatedEvent)
 			elseif quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
 				local v = 1 - 0.5 * addon.db.profile.qualityOpacity
 				texture, blendMode, r, g, b = true, "MOD", v, v, v
+
+				if Masque then
+					-- Do nothing here: Masque hook will handle icon + border tint
+					texture = nil -- prevent overwriting the Masque border here
+				end
 			end
 		end
 		if texture then
@@ -480,15 +485,37 @@ if Masque then
 		self.masqueData.Border      = iqTex
 		self.masqueData.QuestBorder = iqTex
 
+		local icon  = self.IconTexture
+
+
 		-- 2.b) Post-Masque: just force-show the texture if needed
-		if isQuest or isJunk then
+		if isQuest then
 			iqTex:SetDrawLayer("OVERLAY", 7)
+			iqTex:Show()
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
+		elseif isJunk then
+			-- 1) icon: alpha-blend for a light fade, not full MOD tint
+			local base = addon.db.profile.qualityOpacity or 1
+			local v    = 1 - 0.25 * base   -- tweak “0.25” to taste (0.2–0.3 is nice)
+
+			icon:SetBlendMode("BLEND")
+			icon:SetVertexColor(1, 1, 1, 0.4)
+			icon:SetDrawLayer("OVERLAY", 7)
+
+			iqTex:SetBlendMode("BLEND")
+			iqTex:SetDrawLayer("BACKGROUND", 7)
 			iqTex:Show()
 		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
 			local r, g, b = GetItemQualityColor(quality)
 			iqTex:SetVertexColor(r, g, b, addon.db.profile.qualityOpacity)
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
+		else
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
 		end
 		-- (everything else—common items & empty slots—will now use Masque’s defaults)
 	end)

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -431,20 +431,21 @@ end
 --------------------------------------------------------------------------------
 
 if Masque then
-	-- 1px transparent frame for dummy texture (as in your original code)
+	-- 1px transparent frame for dummy texture
 	local dummyFrame = CreateFrame("Frame", "AdiBagsMasqueDummy", UIParent)
 	dummyFrame:SetSize(1, 1); dummyFrame:SetAlpha(0)
+
 	local dummyTex = dummyFrame:CreateTexture(nil, "OVERLAY")
 	dummyTex:SetAllPoints(dummyFrame); dummyTex:SetAlpha(0)
 
-	-- 1) Prepare the data Masque expects for every button (your original)
+	-- 1) Prepare the data Masque expects for every button
 	hooksecurefunc(buttonProto, "OnCreate", function(self)
 		self.masqueData = {
 			Icon        = self.IconTexture,
 			Cooldown    = self.Cooldown,
 			Normal      = self.NormalTexture,
-			Border      = self.IconQuestTexture, -- Always use IconQuestTexture
-			QuestBorder = self.IconQuestTexture, -- Always use IconQuestTexture
+			Border      = self.IconQuestTexture,
+			QuestBorder = self.IconQuestTexture,
 			HotKey      = self.Stock,
 			Count       = self.Count,
 		}
@@ -458,9 +459,8 @@ if Masque then
 
 		if self.hasItem then
 			local _, _, q = GetItemInfo(self.itemId); quality = q
-			-- Using var names from your initially provided Masque hook
-			local questItemInfo, questIdInfo = GetContainerItemQuestInfo(self.bag, self.slot)
-			if addon.db.profile.questIndicator and (questItemInfo or questIdInfo) then
+			local questItem, questId = GetContainerItemQuestInfo(self.bag, self.slot)
+			if addon.db.profile.questIndicator and (questItem or questId) then
 				isQuest = true
 			end
 			if quality == ITEM_QUALITY_POOR and addon.db.profile.dimJunk then
@@ -468,91 +468,59 @@ if Masque then
 			end
 		end
 
-		-- [[ CHANGE #1: Always use iqTex for Masque's Border target ]]
-		-- The self.masqueData.Border and .QuestBorder are already set to iqTex
-		-- in OnCreate. So, the conditional assignment to dummyTex is removed.
-		-- (Original code that set self.masqueData.Border to dummyTex for junk is removed)
-
-		-- Re-register so Masque reapplies its skin.
-		-- Masque will now always attempt to skin iqTex for its "Border" region.
-		if self.masqueGroup and self.masqueGroup.AddButton then
-			self.masqueGroup:RemoveButton(self)
-			self.masqueGroup:AddButton(self, self.masqueData)
+		-- 2.a) Tell Masque to ignore the real border for junk items
+		if isJunk then
+			self.masqueData.Border      = dummyTex
+			self.masqueData.QuestBorder = dummyTex
+		else
+			self.masqueData.Border      = iqTex
+			self.masqueData.QuestBorder = iqTex
 		end
 
-		-- (Original code that restored self.masqueData.Border from dummyTex is also removed as it's not needed)
+		-- Re-register so Masque reapplies its skin
+		self.masqueGroup:RemoveButton(self)
+		self.masqueGroup:AddButton(self, self.masqueData)
+
+		-- Restore for next run
+		self.masqueData.Border      = iqTex
+		self.masqueData.QuestBorder = iqTex
 
 		local icon  = self.IconTexture
 
-		-- 2.b) Post-Masque: Apply AdiBags-specific visual adjustments.
-		-- The original non-Masque UpdateBorder function has already run.
-		-- Masque has just (re)skinned the button. Now AdiBags makes final tweaks.
 
-		-- Default icon appearance (will be overridden by specific cases)
-		icon:SetBlendMode("DISABLE")
-		icon:SetVertexColor(1, 1, 1, 1)
-		if icon.SetDrawLayer then icon:SetDrawLayer("ARTWORK", 4) end -- A common default layer
-
-		-- By default, assume iqTex should be hidden unless a condition shows it.
-		-- The original UpdateBorder function *should* hide iqTex if no AdiBags border condition is met
-		-- (specifically, if 'texture' is nil in that function, it calls iqTex:Hide()).
-		-- We will rely on that and only Show() iqTex if AdiBags needs to display a border.
-		-- If Masque is meant to show a border *always*, this Show/Hide logic needs adjustment.
-		-- For now, let's ensure it's hidden by default in this hook, then shown if needed.
-		iqTex:Hide()
-
-
+		-- 2.b) Post-Masque: just force-show the texture if needed
 		if isQuest then
-			-- This is your original Masque hook logic for quest items.
-			-- It assumes original UpdateBorder set the texture on iqTex.
-			-- Masque might skin iqTex, then AdiBags ensures its quest look.
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
 			icon:SetBlendMode("DISABLE")
 			icon:SetVertexColor(1, 1, 1, 1)
-
 		elseif isJunk then
-			-- [[ CHANGE #2: Junk item handling ]]
-			-- Dim the icon as per your original logic
+			-- 1) icon: alpha-blend for a light fade, not full MOD tint
 			local base = addon.db.profile.qualityOpacity or 1
+			local v    = 1 - 0.25 * base   -- tweak “0.25” to taste (0.2–0.3 is nice)
+
 			icon:SetBlendMode("BLEND")
 			icon:SetVertexColor(1, 1, 1, 0.4)
-			if icon.SetDrawLayer then icon:SetDrawLayer("OVERLAY", 7) end -- Icon on top
+			icon:SetDrawLayer("OVERLAY", 7)
 
-			-- For IconQuestTexture (iqTex), Masque should have applied its border skin.
-			-- AdiBags will *not* set texture or color. It will just ensure it's visible
-			-- on an appropriate layer.
-			iqTex:SetTexture(nil)             -- Explicitly clear AdiBags texture (if any was set by mistake)
-			iqTex:SetVertexColor(1, 1, 1, 1)  -- Ensure no AdiBags tint
-			iqTex:SetBlendMode("BLEND")       -- A common default blend mode
-
-			-- Set draw layer for Masque's border to be visible.
-			-- Needs to be above NormalTexture. "OVERLAY" stratum is typical for borders.
-			-- Sublevel 0 or 1 is often just above the button face.
-			-- If IconTexture is at OVERLAY,7, this border might be behind or frame it.
-			iqTex:SetDrawLayer("OVERLAY", 1)  -- Experiment with this layer. Try 0, 1, or 6.
-			iqTex:Show()                      -- Show the border Masque has (hopefully) drawn.
-
+			iqTex:SetBlendMode("BLEND")
+			iqTex:SetDrawLayer("BACKGROUND", 7)
+			iqTex:Show()
 		elseif quality and quality >= ITEM_QUALITY_UNCOMMON then
-			-- This is your original Masque hook logic for quality items.
-			-- Masque skins iqTex, AdiBags tints it.
 			local r, g, b = GetItemQualityColor(quality)
-			local qualityOpacity = addon.db.profile.qualityOpacity
-			if type(qualityOpacity) ~= "number" then qualityOpacity = 1 end
-
-			iqTex:SetVertexColor(r, g, b, qualityOpacity)
+			iqTex:SetVertexColor(r, g, b, addon.db.profile.qualityOpacity)
 			iqTex:SetDrawLayer("OVERLAY", 7)
 			iqTex:Show()
 			icon:SetBlendMode("DISABLE")
 			icon:SetVertexColor(1, 1, 1, 1)
 		else
-			-- No special AdiBags border (common, empty slots).
-			-- iqTex is already set to Hide() at the start of this conditional block.
-			-- Icon is already reset to its default.
+			icon:SetBlendMode("DISABLE")
+			icon:SetVertexColor(1, 1, 1, 1)
 		end
+		-- (everything else—common items & empty slots—will now use Masque’s defaults)
 	end)
 
-	-- 3) Masque groups (your original)
+	-- 3) Masque groups (unchanged)
 	buttonProto.masqueGroup     = Masque:Group(addonName, addon.L["Backpack button"])
 	bankButtonProto.masqueGroup = Masque:Group(addonName, addon.L["Bank button"])
 end


### PR DESCRIPTION
Supported Masque skins for #5 
- ✅ Caith  
- ✅ Lifestep – XLT  
- ✅ All Entropy (10+) skins  

Other skins still need their own little miracles to happen — just like the ones above got.
